### PR TITLE
prov/gni: some fixes for vec accelerator

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -375,11 +375,9 @@ struct gnix_fid_ep {
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *nic;
 	fastlock_t vc_lock;
-	union {
-		struct gnix_hashtable *vc_ht;
-		struct gnix_vector *vc_table;   /* used for FI_AV_TABLE */
-		struct gnix_vc *vc;		/* used for FI_EP_MSG */
-	};
+	struct gnix_hashtable *vc_ht;
+	struct gnix_vector *vc_table;   /* used for FI_AV_TABLE */
+	struct gnix_vc *vc;		/* used for FI_EP_MSG */
 	/* lock for unexp and posted recv queue */
 	fastlock_t recv_queue_lock;
 	/* used for unexpected receives */


### PR DESCRIPTION
simplify things by retaining the vc hash table
for use with connection setup, irrespective of
whether the EP is bound to an FI_AV_TABLE or
FI_AV_MAP flavor of AV.
@e-harvey 

Signed-off-by: Howard Pritchard howardp@lanl.gov
